### PR TITLE
Update README.md installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ More info: http://emberigniter.com/saving-models-relationships-json-api/
 
 ## Installation
 
-* `ember install ember-data-save-relationships`
+* `npm install --save-dev 'laborvoices/ember-data-save-relationships#master'`
 
 ## Notes
 


### PR DESCRIPTION
Doing `ember install ember-data-save-relationships` pulls in the wrong version (0.0.5) which has no support for includes syntax. I got caught on this for a couple hours. We can either update the readme or publish a new version?