### PR TITLE
Allow for configurable internalModel ID key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ More info: http://emberigniter.com/saving-models-relationships-json-api/
   ```
  - Calling `serialize: true` on cyclic dependencies will result in a stack overflow
  - At this point in time, if your server returns updated `attributes`, these will **not** be updated in the Ember Data store
+ - The internal model temporary `__id__` key is configurable via an environment config:
+ ```
+ ENV['ember-data-save-relationships'] = {
+   internalModelKey: '--id--'
+ };
+ ```
 
 ## Issues
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,8 +1,19 @@
 import Mixin from '@ember/object/mixin';
 import Ember from 'ember';
 import { singularize } from 'ember-inflector';
+import { get, computed } from '@ember/object';
+import { getOwner } from '@ember/application';
 
 export default Mixin.create({
+
+  internalModelKey: computed(function() {
+    var applicationConfig = getOwner(this).resolveRegistration('config:environment');
+    if (applicationConfig['ember-data-save-relationships'] && applicationConfig['ember-data-save-relationships']['internalModelKey']) {
+      return applicationConfig['ember-data-save-relationships']['internalModelKey'];
+    } else {
+      return '__id__';
+    }
+  }),
 
   serializeRelationship(snapshot, data, rel) {
     const relKind = rel.kind;
@@ -50,8 +61,9 @@ export default Mixin.create({
       {
         serialized.data.attributes = {};
       }
-      serialized.data.attributes.__id__ = obj.record.get('_internalModel')[Ember.GUID_KEY];
-      this.get('_visitedRecordIds')[serialized.data.attributes.__id__] = {};
+      let internalModelKey = get(this, 'internalModelKey');
+      serialized.data.attributes[internalModelKey] = obj.record.get('_internalModel')[Ember.GUID_KEY];
+      this.get('_visitedRecordIds')[serialized.data.attributes[internalModelKey]] = {};
     }
 
 
@@ -85,13 +97,14 @@ export default Mixin.create({
   },
   
   updateRecord(json, store) {
-    if (json.attributes !== undefined && json.attributes.__id__ !== undefined)
+    let internalModelKey = get(this, 'internalModelKey');
+    if (json.attributes !== undefined && json.attributes[internalModelKey] !== undefined)
     {
       json.type = singularize(json.type);
       
       const record = store.peekAll(json.type)
         .filterBy('currentState.stateName', "root.loaded.created.uncommitted")
-        .findBy('_internalModel.' + Ember.GUID_KEY, json.attributes.__id__);
+        .findBy('_internalModel.' + Ember.GUID_KEY, json.attributes[internalModelKey]);
 
       if (record) {
         // record.unloadRecord();

--- a/tests/integration/serializers/save-relationships-mixin-alt-config-test.js
+++ b/tests/integration/serializers/save-relationships-mixin-alt-config-test.js
@@ -1,0 +1,144 @@
+import { run } from '@ember/runloop';
+import EmberObject from '@ember/object';
+import Ember from 'ember';
+import QUnit from 'qunit';
+import { module, test } from 'qunit';
+import DS from 'ember-data';
+import SaveRelationshipsMixin from 'ember-data-save-relationships';
+
+var registry, store, Artist, Album, Track, ContactPerson, SimpleModel, SimpleModelContainer;
+
+QUnit.dump.maxDepth = 15;
+
+module('serializers/save-relationships-mixin', {
+  
+  beforeEach() {
+    
+    registry = new Ember.Registry();
+
+    const Owner = EmberObject.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin);
+    const owner = Owner.create({
+      __registry__: registry
+    });
+    const container = registry.container({
+      owner: owner
+    });
+    owner.__container__ = container;
+    
+    SimpleModel = DS.Model.extend({
+    });
+    
+    SimpleModelContainer = DS.Model.extend({
+      model: DS.belongsTo('simple-model'),
+    });
+    
+    ContactPerson = DS.Model.extend({
+      name: DS.attr()
+    });
+    
+    Artist = DS.Model.extend({
+      name: DS.attr(),
+      contactPerson: DS.belongsTo(),
+      albums: DS.hasMany('album')
+    });
+    
+    Album = DS.Model.extend({
+      name: DS.attr(),
+      artist: DS.belongsTo('artist'),
+      tracks: DS.hasMany('track')
+    });
+
+    Track = DS.Model.extend({
+      name: DS.attr(),
+      album: DS.belongsTo('album')
+    });
+
+    const ConfigEnv = EmberObject.extend();
+    ConfigEnv['ember-data-save-relationships'] = {
+        internalModelKey: '--id--'
+    };
+
+    registry.register('config:environment', ConfigEnv);
+    registry.register('model:contact-person', ContactPerson);
+    registry.register('model:artist', Artist);
+    registry.register('model:album', Album);
+    registry.register('model:track', Track);
+    registry.register('model:simple-model', SimpleModel);
+    registry.register('model:simple-model-container', SimpleModelContainer);
+    
+    registry.register('service:store', DS.Store.extend({ adapter: '-default' }));
+        
+    store = container.lookup('service:store');
+    
+    registry.register('adapter:application', DS.JSONAPIAdapter);
+    registry.register('serializer:application', DS.JSONAPISerializer);
+    
+  },
+  
+  afterEach() {
+    run(store, 'destroy');
+  }
+
+});
+
+test("serialize artist with embedded albums (with ID set/configured to non-default key)", function(assert) {
+
+  registry.register('serializer:artist', DS.JSONAPISerializer.extend(SaveRelationshipsMixin, {
+    attrs: {
+      albums: { serialize: true },
+      contactPerson: { serialize: false }
+    }
+  }));
+
+  registry.register('serializer:album', DS.JSONAPISerializer.extend(SaveRelationshipsMixin, {
+    attrs: {
+      artist: { serialize: false }
+    }
+  }));
+
+  registry.register('serializer:track', DS.JSONAPISerializer.extend(SaveRelationshipsMixin, {
+    attrs: {
+      album: { serialize: false }
+    }
+  }));
+
+  const serializer = store.serializerFor("artist");
+  let artistJSON;
+  
+  run(function() {
+    
+    const artist = store.createRecord('artist', { name: "Radiohead" });
+    const album1 = store.createRecord('album', { name: "Kid A" });
+    const album2 = store.createRecord('album', { name: "Kid B" });
+    const album3 = store.createRecord('album', { name: "Kid C" });
+
+    serializer.serialize(artist._createSnapshot());
+
+    artist.get('albums').pushObjects([album1, album2, album3]);
+  
+    assert.equal(artist.get('albums.length'), 3);
+    
+    artistJSON = serializer.serialize(artist._createSnapshot());
+
+    const albumsJSON = { data: [
+      { attributes: { name: 'Kid A', '--id--': getInternalId(album1) },
+        type: 'albums' },
+      { attributes: { name: 'Kid B', '--id--': getInternalId(album2) },
+        type: 'albums' },
+      { attributes: { name: 'Kid C', '--id--': getInternalId(album3) },
+      type: 'albums' } ]
+    };
+
+    assert.deepEqual(artistJSON, { data: {
+        attributes: { name: 'Radiohead' },
+        relationships: { albums: albumsJSON },
+        type: 'artists'
+      }
+    });
+
+  });
+});
+
+function getInternalId(model) {
+  return model.get('_internalModel')[Ember.GUID_KEY];
+}

--- a/tests/integration/serializers/save-relationships-mixin-test.js
+++ b/tests/integration/serializers/save-relationships-mixin-test.js
@@ -52,7 +52,10 @@ module('serializers/save-relationships-mixin', {
       name: DS.attr(),
       album: DS.belongsTo('album')
     });
+
+    const ConfigEnv = EmberObject.extend();
     
+    registry.register('config:environment', ConfigEnv);
     registry.register('model:contact-person', ContactPerson);
     registry.register('model:artist', Artist);
     registry.register('model:album', Album);


### PR DESCRIPTION
The change here is to allow for a configurable internalModelKey. This adds some flexibility to the addon to be used with backends that require a specific key notation or return an altered key due to JSON serialization at the backend.

I hope it's a useful feature and thank you for the great addon, really helpful!