### PR TITLE
Fix mapping of model name to use JSONAPISerializer.modelNameFromPaylo…

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,5 @@
 import Mixin from '@ember/object/mixin';
 import Ember from 'ember';
-import { singularize } from 'ember-inflector';
 import { get, computed } from '@ember/object';
 import { getOwner } from '@ember/application';
 
@@ -101,7 +100,7 @@ export default Mixin.create({
     let internalModelKey = get(this, 'internalModelKey');
     if (json.attributes !== undefined && json.attributes[internalModelKey] !== undefined)
     {
-      json.type = singularize(json.type);
+      json.type = this.modelNameFromPayloadKey(json.type);
 
       const record = store.peekAll(json.type)
         .filterBy('currentState.stateName', "root.loaded.created.uncommitted")


### PR DESCRIPTION
…adKey() method

Our team ran into a problem with a customized mapping for JSONAPI model names.  To fix this, we had to change ember-data-saverelationships to call the .modelNameFromPayloadKey() method which is the proper function for this.

https://api.emberjs.com/ember-data/3.15/classes/JSONAPISerializer/methods/modelNameFromPayloadKey?anchor=modelNameFromPayloadKey

NOTE: this change assumes the SaveRelationshipsMixin is meant to be used with JSONAPISerializer.extend (otherwise the method modelNameFromPayloadKey() wont exist.